### PR TITLE
fix: Like button wasn't filtered properly

### DIFF
--- a/src/lib/posts/Likes.svelte
+++ b/src/lib/posts/Likes.svelte
@@ -34,7 +34,7 @@
 
         pb.collection('likes')
             .getList<LikesResponse<any>>(1, 1, {
-                filter: `user.id = "${$currentUser?.id}"`,
+                filter: `user.id = "${$currentUser?.id}" && post.id = "${post.id}"`,
             })
             .then((likes) => (userLike = likes.items[0]))
 


### PR DESCRIPTION
The like button was only filtering based on user, meaning unliking would delete a like from a random post